### PR TITLE
feat(keeprok) 11/28 : ref.currnet의 흐름에따라 사진변화 movebtn기능진행

### DIFF
--- a/src/components/LargeAlbum.js
+++ b/src/components/LargeAlbum.js
@@ -1,21 +1,19 @@
-const LargeData = () => {
-    const Image1 = () => (
-        <img src="https://cdnimg.melon.co.kr/svc/images/main/imgUrl20231114014430.jpg/melon/quality/80" />
-    );
-
-    const Image2 = () => (
-        <img src="https://cdnimg.melon.co.kr/svc/images/main/imgUrl20231114014449.jpg/melon/quality/80" />
-    );
-
-    const Image3 = () => (
-        <img src="https://cdnimg.melon.co.kr/svc/images/main/imgUrl20231113050531.jpg/melon/quality/80" />
-    );
-    const Image4 = () => (
-        <img src="https://cdnimg.melon.co.kr/svc/images/main/imgUrl20231110035157.png/melon/quality/80" />
-    );
-    const LargeAlbum = [Image1, Image2, Image3, Image4];
-
-    return LargeAlbum;
-};
-export default LargeData;
+export const LargeData = [
+    {
+        Image: 'https://cdnimg.melon.co.kr/svc/images/main/imgUrl20231114014430.jpg/melon/quality/80',
+    },
+    {
+        Image: 'https://cdnimg.melon.co.kr/svc/images/main/imgUrl20231114014449.jpg/melon/quality/80',
+    },
+    {
+        Image: 'https://cdnimg.melon.co.kr/svc/images/main/imgUrl20231113050531.jpg/melon/quality/80',
+    },
+    {
+        Image: 'https://cdnimg.melon.co.kr/svc/images/main/imgUrl20231110035157.png/melon/quality/80',
+    },
+    // { cor: 'red' },
+    // { cor: 'blue' },
+    // { cor: 'green' },
+    // { cor: 'black' },
+];
 // 여기서 완성시키고 export하면 생각에서 만들어봄 불러와서 .current하는 과정에 끝남

--- a/src/pages/main/components/LargeAlbum.js
+++ b/src/pages/main/components/LargeAlbum.js
@@ -4,57 +4,28 @@
 import { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
-import LargeData from '../../../components/LargeAlbum';
+import { LargeData } from '../../../components/LargeAlbum';
+
 //image어떻게 찍히는 지 확인
-import Image1 from '../../../components/LargeAlbum';
+//import Image1 from '../../../components/LargeAlbum';
 // import img1 from 'https://cdnimg.melon.co.kr/svc/images/main/imgUrl20231114014430.jpg/melon/quality/80';
 
 const LargeAlbum = () => {
     //const [state, setState] = useState(LargeData.LargeData);
+    const [Data, setData] = useState(LargeData);
     const [startBtn, setStartBtn] = useState(false);
     let largeRef = useRef(0);
-    let albumRef = useRef([]);
-    //clearinterveal 똑바로 이해못함
-    // useEffect(() => {
-    //     setInterval(() => {
-    //         albumRef.current = LargeData.LargeData[largeRef.current];
-    //         console.log(largeRef.current);
-    //          largeRef.current++;
-    //         setState(state => albumRef.current);
-    //         if (largeRef.current > 3) {
-    //             largeRef.current = 0;
-    //         }
-    //     }, 4000);
-    //     return () => clearInterval(largeRef);
-    // }, [startBtn]);
-    //IF문으로사용할려고하는데 CONSOLE에서 0~3까지 게속찍힘
-    // if (startBtn === false) {
-    //     setInterval(() => {
-    //         albumRef.current = LargeData.LargeData[largeRef.current];
-    //         console.log(largeRef.current);
-    //         largeRef.current++;
-    //         setState(state => albumRef.current);
-    //         if (largeRef.current > 3) {
-    //             largeRef.current = 0;
-    //         }
-    //     }, 4000);
-    // }
-    // img를 컴포넌트로 안하고 여기에 불러오면 어떨가 해서 실험
-    // const LargeImg = [
-    //     { image: picture1 },
-    //     { image: picture2 },
-    //     { image: picture3 },
-    //     { image: picture4 },
-    // ];
-    // 3페어꺼 보고   clearinterval을빼먹은것을 알게됨
+    let album = [];
     useEffect(() => {
         if (startBtn === false) {
             const interval = setInterval(() => {
-                albumRef.current = LargeData[largeRef.current];
+                album.current = LargeData[largeRef.current];
+
                 console.log(largeRef.current);
                 largeRef.current++;
-                console.log(albumRef.current);
-                console.log(Image1);
+                console.log(LargeData[0].Image);
+                console.log(album.current.Image);
+                setData(Data => album.current);
                 //setState(state => albumRef.current);
                 if (largeRef.current > 3) {
                     largeRef.current = 0;
@@ -63,6 +34,10 @@ const LargeAlbum = () => {
             return () => clearInterval(interval);
         }
     }, [startBtn]);
+    //로딩이되자마자 이벤트 실행( use effect)=>count 흐름
+    // 버튼 클릭시 사진 변경(count마다 사진 변경그래야 movebtn 즉시 변화가능)
+    // (new함수 생성=>currnt변수들 집어넣을 (사진들)
+
     //state이용해서 해야되는데 생각만하고 못함 +정리
     const index0Btn = () => {
         largeRef.current = 0;
@@ -102,7 +77,7 @@ const LargeAlbum = () => {
                 </Styled.PlayContain>
 
                 <Styled.EventPart>
-                    <LargeData />
+                    <img src={Data.Image}></img>
                 </Styled.EventPart>
             </Styled.EventList>
         </Styled.Wrapper>
@@ -128,6 +103,7 @@ const EventPart = styled.a`
     width: 236px;
     height: 315px;
 `;
+
 //움직이는 버튼모음
 const PlayContain = styled.div`
     position: absolute;

--- a/src/pages/main/components/LatestAlbum/LatestAlbum.js
+++ b/src/pages/main/components/LatestAlbum/LatestAlbum.js
@@ -43,7 +43,6 @@ const LatestAlbum = () => {
                             <a onClick={() => {}}>전체</a>
                         </Styled.CategoryName>
                         <Styled.CategoryName>
-
                             <a onClick={() => onClickFilterCategory('국내')}>
                                 국내
                             </a>
@@ -52,7 +51,6 @@ const LatestAlbum = () => {
                             <a onClick={() => onClickFilterCategory('해외')}>
                                 해외
                             </a>
-
                         </Styled.CategoryName>
                         <Styled.CategoryIndex>
                             <Styled.CategoryIndex>


### PR DESCRIPTION
 - 4초의간격으로 사진들이 순서에 맞게 변경되게 기능을 집어넣음
 
- 버튼 클릭시 사진 변경-즉각적으로 안됨 - state변경시 실행이안됨

- state변경버튼제외하고 나머지 버튼 기능넣을 예정

- 이미지 로드의 경우 useeffect안에서 불러와서 사용은 되고있지만 state로 지정을 안해줘서 랜더가 안되는 점을 생각해 usestate를 통해 img주소를 불러왔습니다